### PR TITLE
authorise dependency json pickle >= 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
         py_modules=['vakt'],
         python_requires='>=3.4',
         install_requires=[
-            'jsonpickle~=1.0',
+            'jsonpickle>=1.0',
         ],
         extras_require={
             'dev': [


### PR DESCRIPTION
Small update in setup.py to accept jsonpickle >= 1.0
since last vakt release, jsonpickle added compat with python 3.10 and 3.11 and forcing to 1.x may cause depencies problems.

All unittests are fine after this upgrade.